### PR TITLE
ci: deploy on dev after building docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -73,3 +73,16 @@ jobs:
           tags: gcr.io/tendermint-dev/emeris-cns-server:${{ steps.get_version.outputs.version-without-v }},gcr.io/tendermint-dev/emeris-cns-server:${{ github.sha }}
           build-args: |
             GIT_TOKEN=${{ secrets.TENDERBOT_GIT_TOKEN }}
+
+  deploy-on-dev:
+    runs-on: self-hosted
+    needs: cns-server
+
+    steps:
+      - name: Call repository_dispatch on demeris-backend
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.TENDERBOT_GIT_TOKEN }}
+          repository: allinbits/demeris-backend
+          event-type: dev-push-cns-server
+          client-payload: '{"repo_name":"emeris-cns-server","branch_name":"main","image_name":"emeris-cns-server","image_sha":"${{ github.sha }}","service_name":"cns-server"}'


### PR DESCRIPTION
This pull request enables this repo to push changes into dev env as long as the Docker build action finishes successfully.

Ref: https://github.com/allinbits/demeris-backend/issues/259.