### PR TITLE
fix: only build/push on dev code from main branch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,9 +2,6 @@ name: Build Docker images
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
Before this commit any PR would trigger docker build+push on dev.

This is to be avoided because WIP code could break other parts of the dev cluster (e.g. database `ALTER TABLE` statements might break `api-server` queries).