### PR TITLE
Expose env var for disabled OAuth

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               value: "{{ .Values.redirectURL }}"
             {{- if .Values.test }}
             - name: DEMERIS-CNS_ENV
-              value: "{{ .Values.environment }}"
+              value: "test"
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -27,4 +27,4 @@ k8sNamespace: emeris
 redirectURL: https://admin.emeris.com/login
 
 # 'test' disables OAuth. Do not change outside of controlled envs!
-environment: live
+test: false


### PR DESCRIPTION
Expose the `environment` variable to allow unsecured deployment in local/dev
This will facilitate automatic [DEV environment creation](https://github.com/allinbits/demeris-backend/pull/527/files#diff-5b8f59c8472538dd74e096b6d41befe1e2ce33cbddecb6c6cbda05bc1f6a4a85R322)